### PR TITLE
Blog cleanup: Fix typos in Nuxt 4 upgrade article

### DIFF
--- a/content/2025/07/21/upgrading-my-static-nuxt-blog-from-nuxt-3-to-nuxt-4.md
+++ b/content/2025/07/21/upgrading-my-static-nuxt-blog-from-nuxt-3-to-nuxt-4.md
@@ -283,7 +283,7 @@ yarn dev
 
 OK, we have an error related to i18n. I have struggled with i18n a fair bit when doing major changes to my site.
 
-It looks like Nuxt 4 expects the i18n folder to be under tha new `/app` directory, but it is still in the root directory, so let's move that and try running `yarn dev` again.
+It looks like Nuxt 4 expects the i18n folder to be under the new `/app` directory, but it is still in the root directory, so let's move that and try running `yarn dev` again.
 
 Cool, no errors:
 
@@ -378,7 +378,7 @@ After upgrading `@nuxtjs/i18n` to v10.0.0 I got another i18n error when running 
     at async initialize (node_modules/@nuxt/cli/dist/chunks/index.mjs:426:3)
 ```
 
-OK! So I rarranged my `i18n` folder to match watch it was looking for:
+OK! So I rearranged my `i18n` folder to match what it was looking for:
 
 ```
 ~/git/briancaffey.github.io$ tree i18n -L 3


### PR DESCRIPTION
## Changes Made

### Typos Fixed
- Fixed typo: 'tha new  directory' → 'the new  directory'
- Fixed typo: 'rarranged my  folder to match watch' → 'rearranged my  folder to match what'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or build impact.
> 
> **Overview**
> Fixes two minor typos in the Nuxt 4 upgrade blog post (`tha`→`the`, `rarranged...watch`→`rearranged...what`) without changing any code or behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c2f2989ef8fb3da3431e0f4fe8aba237d0bb06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->