### PR TITLE
Polish Nuxt 4 upgrade article (typos + version disclaimer)

### DIFF
--- a/content/2025/07/21/upgrading-my-static-nuxt-blog-from-nuxt-3-to-nuxt-4.md
+++ b/content/2025/07/21/upgrading-my-static-nuxt-blog-from-nuxt-3-to-nuxt-4.md
@@ -17,6 +17,8 @@ comments: true
 
 This article will share my experience upgrading my Nuxt blog from Nuxt 3 to Nuxt 4. I'm following the official [Upgrade Guide](https://nuxt.com/docs/4.x/getting-started/upgrade) from Nuxt. It will be mostly unfiltered and I'll try to document things as they happen. Let's go!
 
+**Version Note:** This article was published in July 2025 (~8 months old) and references specific versions (Nuxt 4.0.0, Node 22.17.1, @nuxtjs/i18n v10, etc.). These packages evolve quickly; check official documentation for current best practices, breaking changes, and updated migration steps before implementing similar upgrades today.
+
 First, I'll do this on a new branch:
 
 ```
@@ -378,7 +380,7 @@ After upgrading `@nuxtjs/i18n` to v10.0.0 I got another i18n error when running 
     at async initialize (node_modules/@nuxt/cli/dist/chunks/index.mjs:426:3)
 ```
 
-OK! So I rarranged my `i18n` folder to match watch it was looking for:
+OK! So I rearranged my `i18n` folder to match what it was looking for:
 
 ```
 ~/git/briancaffey.github.io$ tree i18n -L 3


### PR DESCRIPTION
Summary:
- Fixed 2 typos in the real-time migration narrative ('rarranged' → 'rearranged', 'watch' → 'what')
- Added version disclaimer noting July 2025 publication and specific package versions referenced
- Preserved the unfiltered, step-by-step debugging style that makes this article valuable

The article captures a genuine Nuxt 3→4 migration journey with all its real-time problem-solving intact. The version disclaimer helps readers understand these are specific versions from mid-2025.